### PR TITLE
Fixed CMakeLists.txt for Cygwin platform.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,11 +190,21 @@ CHECK_INCLUDE_FILES (dlfcn.h               HAVE_DLFCN_H)
 CHECK_INCLUDE_FILES (unistd.h              HAVE_UNISTD_H)
 
 # Include order matters for these windows files.
-CHECK_INCLUDE_FILES ("winsock2.h;windows.h"            HAVE_WINSOCK2_H)
-CHECK_INCLUDE_FILES ("winsock2.h;ws2tcpip.h;windows.h" HAVE_WS2TCPIP_H)
-CHECK_INCLUDE_FILES ("winsock.h;windows.h"             HAVE_WINSOCK_H)
-CHECK_INCLUDE_FILES (windows.h                         HAVE_WINDOWS_H)
-
+# If the platform is Cygwin and MinGW is not used, don't try to
+# find Winsock header files. You would find them but obviously
+# we shouldn't include them. Otherwise you would see a bunch of
+# conflicting types errors.
+IF (CYGWIN AND NOT MINGW)
+	SET (HAVE_WINSOCK2_H FALSE)
+	SET (HAVE_WS2TCPIP_H FALSE)
+	SET (HAVE_WINSOCK_H FALSE)
+	SET (HAVE_WINDOWS_H FALSE)
+ELSE ()
+	CHECK_INCLUDE_FILES ("winsock2.h;windows.h"            HAVE_WINSOCK2_H)
+	CHECK_INCLUDE_FILES ("winsock2.h;ws2tcpip.h;windows.h" HAVE_WS2TCPIP_H)
+	CHECK_INCLUDE_FILES ("winsock.h;windows.h"             HAVE_WINSOCK_H)
+	CHECK_INCLUDE_FILES (windows.h                         HAVE_WINDOWS_H)
+ENDIF()
 
 # Set system-specific compiler flags
 IF (CMAKE_SYSTEM_NAME STREQUAL "Darwin")


### PR DESCRIPTION
If the platform is Cygwin and MinGW is not used, don't try to find Winsock header files. You would find them but obviously we shouldn't include them. Otherwise you would see a bunch of conflicting types errors like:

```bash
$ make
Scanning dependencies of target c-ares
[  1%] Building C object src/lib/CMakeFiles/c-ares.dir/ares__close_sockets.c.o
In file included from /usr/include/w32api/winsock2.h:56,
                 from /home/wanj/c-ares/ares_build.h:26,
                 from /home/wanj/c-ares/src/lib/ares_setup.h:83,
                 from /home/wanj/c-ares/src/lib/ares__close_sockets.c:17:
/usr/include/w32api/psdk_inc/_fd_types.h:100:2: warning: #warning "fd_set and associated macros have been defined in sys/types.      This can cause runtime problems with W32 sockets" [-Wcpp]
  100 | #warning "fd_set and associated macros have been defined in sys/types.  \
      |  ^~~~~~~
In file included from /usr/include/w32api/winsock2.h:57,
                 from /home/wanj/c-ares/ares_build.h:26,
                 from /home/wanj/c-ares/src/lib/ares_setup.h:83,
                 from /home/wanj/c-ares/src/lib/ares__close_sockets.c:17:
/usr/include/w32api/psdk_inc/_ip_types.h:63:8: error: redefinition of ‘struct linger’
   63 | struct linger {
      |        ^~~~~~
In file included from /usr/include/sys/socket.h:13,
                 from /home/wanj/c-ares/ares_build.h:22,
                 from /home/wanj/c-ares/src/lib/ares_setup.h:83,
                 from /home/wanj/c-ares/src/lib/ares__close_sockets.c:17:
/usr/include/cygwin/socket.h:52:8: note: originally defined here
   52 | struct linger {
      |        ^~~~~~
In file included from /usr/include/w32api/winsock2.h:57,
                 from /home/wanj/c-ares/ares_build.h:26,
                 from /home/wanj/c-ares/src/lib/ares_setup.h:83,
                 from /home/wanj/c-ares/src/lib/ares__close_sockets.c:17:
/usr/include/w32api/psdk_inc/_ip_types.h:70:8: error: redefinition of ‘struct sockaddr’
   70 | struct sockaddr {
      |        ^~~~~~~~

...
```